### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     ggplot2,
     methods,
     Rcpp,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     ggmcmc,
     GGally,
@@ -44,8 +44,8 @@ LinkingTo:
     Rcpp,
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Config/testthat/edition: 3
 Suggests: 

--- a/inst/stan/TK.stan
+++ b/inst/stan/TK.stan
@@ -18,11 +18,11 @@ data {
   // Internal concentraion
   // Growth
   int<lower=0> n_out ;
-  real CGobs[lentp, n_out, n_rep];
+  array[lentp, n_out, n_rep] real CGobs;
 
   // Metabolites
   int<lower=0> n_met ;
-  real Cmet[lentp, n_met, n_rep] ;
+  array[lentp, n_met, n_rep] real Cmet ;
 
   real<lower=0> gmaxsup ;
   
@@ -43,11 +43,11 @@ parameters {
   vector[n_met] log10km ;
   vector[n_met] log10kem ;
   
-  real<lower=0> sigmaCGpred[n_out] ; 
+  array[n_out] real<lower=0> sigmaCGpred ; 
   vector<lower=0>[n_met] sigmaCmetpred ;
   
-  real<lower=0> gmax[n_out - 1] ;
-  real<lower=0> G0[n_out -1];
+  array[n_out - 1] real<lower=0> gmax ;
+  array[n_out -1] real<lower=0> G0;
   
 }
 transformed parameters{
@@ -186,10 +186,10 @@ model {
 
 generated quantities {
   
-  real CGobs_out[lentp,n_out]; 
-  real Cmet_out[lentp,n_met];
+  array[lentp,n_out] real CGobs_out; 
+  array[lentp,n_met] real Cmet_out;
 
-  real Cexp_interpol[len_vt, n_exp];
+  array[len_vt, n_exp] real Cexp_interpol;
   //vector[lentp] tp_y ;
   
   for(t in 1:lentp){

--- a/inst/stan/TK_predict.stan
+++ b/inst/stan/TK_predict.stan
@@ -30,14 +30,14 @@ data {
   matrix[N_samples, n_met] log10km ;
   matrix[N_samples, n_met] log10kem ;
 
-  real M[N_samples] ;
-  real E[N_samples] ;
+  array[N_samples] real M ;
+  array[N_samples] real E ;
 
-  real<lower=0> sigmaCGpred[N_samples, n_out] ;
+  array[N_samples, n_out] real<lower=0> sigmaCGpred ;
   matrix<lower=0>[N_samples, n_met] sigmaCmetpred ;
 
-  real<lower=0> gmax[N_samples, n_out - 1] ;
-  real<lower=0> G0[N_samples, n_out -1];
+  array[N_samples, n_out - 1] real<lower=0> gmax ;
+  array[N_samples, n_out -1] real<lower=0> G0;
 
 }
 parameters {
@@ -48,8 +48,8 @@ model {
 }
 generated quantities {
 
-  real CGobs_out[lentp,n_out];
-  real Cmet_out[lentp,n_met];
+  array[lentp,n_out] real CGobs_out;
+  array[lentp,n_met] real Cmet_out;
 
   matrix[lentp, n_exp] Cexp_interpol;
 

--- a/inst/stan/include/linear_interpolation.stan
+++ b/inst/stan/include/linear_interpolation.stan
@@ -24,11 +24,11 @@ real interpolate(real x, vector xpt, vector ypt){
 }
 //}
 
-real[] odeTK(real t,      // time
-             real[] y,    // variables
-             real[] theta,
-             real[] x_r,
-             int[] x_i) {
+array[] real odeTK(real t,      // time
+             array[] real y,    // variables
+             array[] real theta,
+             array[] real x_r,
+             array[] int x_i) {
   
   // parameters
   
@@ -38,20 +38,20 @@ real[] odeTK(real t,      // time
   int n_out = x_i[4] ; 
   int n_met = x_i[5] ;
 
-  real ku[n_exp] = theta[1:n_exp] ;
-  real ke[n_out] = theta[(n_exp+1):(n_exp+n_out)] ;
-  real km[n_met] = theta[(n_exp+n_out+1):(n_exp+n_out+n_met)] ;
-  real kem[n_met] = theta[(n_exp+n_out+n_met+1):(n_exp+n_out+n_met+n_met)] ;
+  array[n_exp] real ku = theta[1:n_exp] ;
+  array[n_out] real ke = theta[(n_exp+1):(n_exp+n_out)] ;
+  array[n_met] real km = theta[(n_exp+n_out+1):(n_exp+n_out+n_met)] ;
+  array[n_met] real kem = theta[(n_exp+n_out+n_met+1):(n_exp+n_out+n_met+n_met)] ;
    
   // vector[1+n_met] dydt ;
-  real dydt[1+n_met] ;
+  array[1+n_met] real dydt ;
   
   real tacc = x_r[1] ;
-  // real tp_rmNA[lentp_rmNA] = x_r[2:(lentp_rmNA+1)] ;
+  // array[lentp_rmNA] real tp_rmNA = x_r[2:(lentp_rmNA+1)] ;
   vector[lentp_rmNA] tp_rmNA = to_vector(x_r[2:(lentp_rmNA+1)]) ;
   // WORK ONLY FOR ONE EXPOSURE PROFILE
   
-  // real Cexp_rmNA[lentp_rmNA] = x_r[(lentp_rmNA+2):(lentp_rmNA+2+lentp_rmNA)] ;
+  // array[lentp_rmNA] real Cexp_rmNA = x_r[(lentp_rmNA+2):(lentp_rmNA+2+lentp_rmNA)] ;
   vector[lentp_rmNA] Cexp_rmNA = to_vector(x_r[(lentp_rmNA+2):(lentp_rmNA+1+lentp_rmNA)]) ;
 
   // latent vairable
@@ -91,12 +91,12 @@ real[] odeTK(real t,      // time
 
 
 // matrix solve_TK(
-//   real[] y0, real t0, real[] ts, real[] theta, int[] n_int,
-//   real tacc, real[] tp_rmNA, real[] Cexp_rmNA, real[] odeParam){
+//   array[] real y0, real t0, array[] real ts, array[] real theta, array[] int n_int,
+//   real tacc, array[] real tp_rmNA, array[] real Cexp_rmNA, array[] real odeParam){
 //     
 //     //vector[1+size(Cexp_rmNA) + size(tp_rmNA)] vector_r ;
-//     real vector_r[1+size(Cexp_rmNA) + size(tp_rmNA)]  ;
-//     // real vector_r[1+size(tp_rmNA)]  ;
+//     array[1+size(Cexp_rmNA) + size(tp_rmNA)] real vector_r  ;
+//     // array[1+size(tp_rmNA)] real vector_r  ;
 //     
 //     vector_r[1] = tacc ;
 //     // vector_r[2:(size(Cexp_rmNA)+1)] = tp_rmNA ;

--- a/inst/stan/odeTK.stan
+++ b/inst/stan/odeTK.stan
@@ -10,7 +10,7 @@ data {
   
   // Time points
   int<lower=0> lentp;
-  real tp[lentp] ;
+  array[lentp] real tp ;
   
   // Exposure profiles
   int<lower=0> n_exp ;
@@ -21,11 +21,11 @@ data {
   // Internal concentraion
   // Growth
   int<lower=0> n_out ;
-  real CGobs[lentp, n_out, n_rep];
+  array[lentp, n_out, n_rep] real CGobs;
 
   // Metabolites
   int<lower=0> n_met ;
-  real Cmet[lentp, n_met, n_rep] ;
+  array[lentp, n_met, n_rep] real Cmet ;
 
   //vector[1+n_met] y0;
   //real t0;
@@ -42,7 +42,7 @@ data {
   vector[len_vt] vt ;
   
   // Parameters for integration of differentiol equations
-  real y0[1+n_met];
+  array[1+n_met] real y0;
   real t0 ;
   
   // real rel_tol;
@@ -50,8 +50,8 @@ data {
   // int max_num_steps;
 }
 transformed data{
-  real x_r[1+lentp_rmNA+lentp_rmNA] ;
-  int x_int[5] ;
+  array[1+lentp_rmNA+lentp_rmNA] real x_r ;
+  array[5] int x_int ;
   
   x_r[1] = tacc ;
   
@@ -75,11 +75,11 @@ parameters {
   vector[n_met] log10km ;
   vector[n_met] log10kem ;
   
-  real<lower=0> sigmaCGpred[n_out] ; 
+  array[n_out] real<lower=0> sigmaCGpred ; 
   vector<lower=0>[n_met] sigmaCmetpred ;
   
-  real<lower=0> gmax[n_out - 1] ;
-  real<lower=0> G0[n_out -1];
+  array[n_out - 1] real<lower=0> gmax ;
+  array[n_out -1] real<lower=0> G0;
   
 }
 transformed parameters{
@@ -95,13 +95,13 @@ transformed parameters{
   matrix[lentp,n_out] CGpred ; 
   matrix[lentp,n_met] Cmetpred ;
 
-  // int n_val[5] ;
+  // array[5] int n_val ;
   // real theta ;
 
-  real y_sim[lentp, 1+n_met] ; 
+  array[lentp, 1+n_met] real y_sim ; 
   // matrix[lentp, 1+n_met] y_sim ;
   
-  real theta[n_exp+n_out+n_met+n_met] ;
+  array[n_exp+n_out+n_met+n_met] real theta ;
   
   for(i in 1:n_exp){
     ku[i] = 10 ^ log10ku[i] ;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

You can now also update your usage of `integrate_ode_rk45` to `ode_rk45` (I saw that you had that code commented out)

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
